### PR TITLE
Updated the REMOD_VERSION flag in the makefile to use git

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -241,9 +241,9 @@ debug-flags: build
 build: revision server
 
 revision:
-SVNVERSION= $(shell svnversion -cn . 2>/dev/null | sed -e "s/.*://" -e "s/\([0-9]*\).*/\1/" | grep "[0-9]") 
-ifneq "$(SVNVERSION)" " "
-override CXXFLAGS+= -DREMOD_VERSION="\"SVN build rev: $(SVNVERSION)\""
+GITVERSION= $(shell git rev-parse HEAD)
+ifneq "$(GITVERSION)" " "
+override CXXFLAGS+= -DREMOD_VERSION="\"at commit $(GITVERSION)\""
 endif
 
 enet/Makefile:

--- a/src/Makefile.win32
+++ b/src/Makefile.win32
@@ -207,9 +207,9 @@ debug-flags: build
 build: revision server
 
 revision:
-SVNVERSION= $(shell svnversion -cn . 2>/dev/null | sed -e "s/.*://" -e "s/\([0-9]*\).*/\1/" | grep "[0-9]") 
-ifneq "$(SVNVERSION)" " "
-override CXXFLAGS+= -DREMOD_VERSION="\"SVN build rev: $(SVNVERSION)\""
+GITVERSION= $(shell git rev-parse HEAD)
+ifneq "$(GITVERSION)" " "
+override CXXFLAGS+= -DREMOD_VERSION="\"at commit $(GITVERSION)\""
 endif
 
 enet/Makefile:


### PR DESCRIPTION
Updated the REMOD_VERSION flag to show correct info from git.
Alternativly we could use
```
git rev-list --count HEAD
```
to retrieve the current "commit number", although it is prefferable to use the commit hash.
Using info command from IRC/ingame works fine again :+1: 