### PR TITLE
AuthControl Module

### DIFF
--- a/scripts/modules/authcontrol.cfg
+++ b/scripts/modules/authcontrol.cfg
@@ -1,0 +1,174 @@
+//AuthControl for Remod by subbed74
+//Adds commands to allow the modification of authkeys in-game
+//IMPORTANT: Requires the authkeys to be stored in the sqlite database, or a MySQL database
+
+//Command aliases
+cmd_addauth = [
+	if (|| (=s $arg4 "m") (=s $arg4 "a")) [
+		//Query to add authkeys
+		db__uid = (db_get_dbuid $auth_db)
+
+		tempstring = (format "SELECT name, pubkey FROM %1 WHERE name='%2' OR pubkey='%3'" $auth_table $arg2 $arg3)
+		authquery = (db_query $tempstring $auth_db)
+
+		if (= $authquery -1) [
+			db_error $auth_db
+		] [
+			authrow = (db_getrow $authquery $auth_db)
+			db_finalize $authquery $auth_db
+
+			if (!=s $authrow "") [
+				pm $arg1 "^f3[ ERROR ] ^f0That key or username is already being used!"
+			] [
+				cases (db_get_engine $auth_db) "sqlite3" [
+					sqlite3_query $db__uid "BEGIN TRANSACTION"
+					sqlite3_pquery $db__uid "INSERT INTO `:0` (name, pubkey, rights, enabled) VALUES (':1', ':2', ':3', 1)" $auth_table $arg2 $arg3 $arg4
+					res = (sqlite3_query $db__uid "COMMIT")
+				] "mysql" [
+					res = (mysql_pquery $db__uid "INSERT INTO `:0` (name, pubkey, rights, enabled) VALUES (':1', ':2', ':3', 1)" $auth_table $arg2 $arg3 $arg4)
+				] [
+					res = -1
+				]
+
+				//Tell the player the key was added
+				if (=s $res -1) [
+					db_error $auth_db
+				] [
+					auth_load_from_db
+					pm $arg1 (format "^f6[ AUTHCONTROL ] ^f0A key was successfully added for ^f5%1 ^f0with ^f5%2 ^f0privileges!" $arg2 (? (=s $arg4 "a") "admin" "master"))
+				]
+			]
+		]
+	] [
+		pm $arg1 "^f3[ ERROR ] ^f0You must provide an ^"a^" or an ^"m^" for admin/master privileges!"
+	]
+]
+
+cmd_authstate = [
+	//Check if user exists
+	db__uid = (db_get_dbuid $auth_db)
+
+	tempstring = (format "SELECT rights FROM %1 WHERE name='%2'" $auth_table $arg2)
+	authquery = (db_query $tempstring $auth_db)
+	if (= $authquery -1) [
+		db_error $auth_db
+	] [
+		authrow = (db_getrow $authquery $auth_db)
+		db_finalize $authquery $auth_db
+
+		if (=s $authrow "") [
+			pm $arg1 (format "^f3[ ERROR ] ^f0No one has an authkey with the name ^f5%1" $arg2)
+		] [  //If user exists, validate the integer
+			cond (= $arg3 -1) [  //Delete the authkey
+				cases (db_get_engine $auth_db) "sqlite3" [
+					sqlite3_query $db__uid "BEGIN TRANSACTION"
+					sqlite3_pquery $db__uid "DELETE FROM `:0` WHERE name=':1'" $auth_table $arg2
+					res = (sqlite3_query $db__uid "COMMIT")
+				] "mysql" [
+					res = (mysql_pquery $db__uid "DELETE FROM `:0` WHERE name=':1'" $auth_table $arg2)
+				] [
+					res = -1
+				]
+
+				//Send a message to the user if successful then reload keys
+				if (= $res -1) [
+					db_error $auth_db
+				] [
+					pm $arg1 (format "^f6[ AUTHCONTROL ] ^f0The authkey for ^f5%1 ^f0was successfully deleted!" $arg2)
+				]
+			] (|| (= $arg3 1) (! $arg3)) [ //Enables/Disables the authkey
+				cases (db_get_engine $auth_db) "sqlite3" [
+					sqlite3_query $db__uid "BEGIN TRANSACTION"
+					sqlite3_pquery $db__uid "UPDATE `:0` SET enabled=:1 WHERE name=':2'" $auth_table $arg3 $arg2
+					res = (sqlite3_query $db__uid "COMMIT")
+				] "mysql" [
+					res = (mysql_pquery $db__uid "UPDATE `:0` SET enabled=:1 WHERE name=':2'" $auth_table $arg3 $arg2)
+				] [
+					res = -1
+				]
+
+				//Send a message to the user if successful then reload keys
+				if (= $res -1) [
+					db_error $auth_db
+				] [
+					pm $arg1 (format "^f6[ AUTHCONTROL ] ^f0The authkey for ^f5%1 ^f0is now: %2" $arg2 (? ($arg3) "enabled" "^f3disabled"))
+				]
+			] [
+				pm $arg1 "^f3[ ERROR ] ^f0You must choose -1, 0, or 1 to change state of this authkey!"
+			]
+		]
+	]
+]
+
+cmd_authpriv = [
+	//Check if user exists
+	db__uid = (db_get_dbuid $auth_db)
+
+	tempstring = (format "SELECT rights FROM %1 WHERE name='%2'" $auth_table $arg2)
+	authquery = (db_query $tempstring $auth_db)
+	if (= $authquery -1) [
+		db_error $auth_db
+	] [
+		authrow = (db_getrow $authquery $auth_db)
+		db_finalize $authquery $auth_db
+
+		if (=s $authrow "") [
+			pm $arg1 (format "^f3[ ERROR ] ^f0No one has an authkey with the name ^f5%1" $arg2)
+		] [ //Change the user's privileges
+			if (&& (!=s $arg3 "m") (!=s $arg3 "a")) [ //Validate the privilege
+				pm $arg1 "^f3[ ERROR ] ^f0You must specify ^"a^" or ^"m^" for the privilege!"
+			] [
+				cases (db_get_engine $auth_db) "sqlite3" [
+					sqlite3_query $db__uid "BEGIN TRANSACTION"
+					sqlite3_pquery $db__uid "UPDATE `:0` SET rights=':1' WHERE name=':2'" $auth_table $arg3 $arg2
+					res = (sqlite3_query $db__uid "COMMIT")
+				] "mysql" [
+					res = (mysql_pquery $db__uid "UPDATE `:0` SET rights=':1' WHERE name=':2'" $auth_table $arg3 $arg2)
+				] [
+					res = -1
+				]
+
+				if (= $res -1) [
+					db_error $auth_db
+				] [
+					pm $arg1 (format "^f6[ AUTHCONTROL ] ^f0Privileges for ^f5%1 ^f0set to %2" $arg2 (? (=s $arg3 "m") "master" "^f6admin"))
+					auth_load_from_db
+				]
+			]
+		]
+	]
+]
+
+cmd_listauth = [
+	// Get all the users
+	db__uid = (db_get_dbuid $auth_db)
+
+	tempstring = (format "SELECT name, rights FROM %1" $auth_table)
+	authquery = (db_query $tempstring $auth_db)
+
+	// Check for error, if no error store data in list
+	if (= $authquery -1) [
+		db_error $auth_db
+	] [
+		auth_list = ""
+
+		// Loop through the data and concat it to the list
+		while [ row = (db_getrow $authquery $auth_db); result (!=s $row "")] [
+			auth_list = (format "%1 %2%3" $auth_list (? (=s (at $row 1) "m") "^f0" "^f6") (at $row 0))
+		]
+		db_finalize $authquery $auth_db
+
+		// PM the list to the user
+		pm $arg1 (format "^f3[ AUTH ] ^f0Users: %1" $auth_list)
+	]
+]
+
+//Register commands
+if (=s $auth_db "") [
+	echo "[ AUTHCONTROL ] Error:  You must use a MySQL or SQLite database for the authkeys to use AuthControl."
+] [
+	registercommand "addauth" cmd_addauth 3 "www" "addauth [NAME] [PUBLIC KEY] [A or M] | Adds an authkey with the given information.  Requires an SQLite or MySQL database."
+	registercommand "authstate" cmd_authstate 3 "wi" "authstate [NAME] [-1|0|1] | Changes the state of an authkey.  -1 = delete, 0 = disable, 1 = enable.  NOTE: You must run ^f5#syncauth ^f0after using this command!"
+	registercommand "authpriv" cmd_authpriv 3 "ww" "authpriv [NAME] [a|m] | Changes the privileges for a user's authkey between master or admin."
+	registercommand "listauth" cmd_listauth 3 "" "listauth | Lists all users with an authkey.  Green names are masters, orange names are admins."
+]

--- a/server-init.cfg.default
+++ b/server-init.cfg.default
@@ -270,6 +270,11 @@ auth_db = "default"
 exec "scripts/modules/syncauth.cfg"
 
 
+//******** Authcontrol module ********
+// Extended commands to allow control of authkeys stored in MySQL/SQLite databases in-game.
+
+exec "scripts/modules/authcontrol.cfg"
+
 
 //******** Spy module ********
 // Collects IP addresses of players and allow you to see players with fake names


### PR DESCRIPTION
Adds commands to control authkeys in-game.  It requires the use of an SQL database for the authkeys.  Syncauth must be used after the commands.

Commands:
---
addauth [NAME] [PUBLIC KEY] [A or M] - Adds a created authkey to the database with the given information.  A/M are Admin/Master respectively.

authstate [NAME] [-1/0/1]  -  Modifies the state of an authkey with the given name.
 - "-1" deletes the key.
 - "0" enables the key.
 - "1" disables the key.

authpriv [NAME] [a/m] - Changes the privileges of an authkey with the given name.  A/m are admin/master respectively.

listauth - Lists all users with authkeys in the database.  The names are green and orange for masters and admins. 