### PR TITLE
Adding simple docker-compose support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3"
+services:
+  sauerbraten:
+    container_name: remod_sauerbraten
+    build:
+      context: ./
+      dockerfile: Dockerfile
+    image: remod_sauerbraten
+    restart: always
+    network_mode: "host"
+    ports:
+      - "28785:28785"
+      - "28786:28786"


### PR DESCRIPTION
Create docker-compose.yml for basic docker-compose usage.
Use docker-compose build for building and tagging the image as remod_sauerbraten. Use docker-compose up [-d] for starting the server and docker-compose down for stopping the server.